### PR TITLE
Fix missing MODULE_LICENSE() complain

### DIFF
--- a/src/galois.c
+++ b/src/galois.c
@@ -37,6 +37,7 @@ plank@cs.utk.edu
 # define free(m) kfree(m)
 # define fprintf(m, fmt, args...) printk("%s:%d " fmt, __FUNCTION__, __LINE__, ##args)
 # define GALOIS_EXPORTED(s) EXPORT_SYMBOL(s)
+MODULE_LICENSE("LGPL v2.1");
 #else /* !__KERNEL__ */
 # include <stdio.h>
 # include <stdlib.h>


### PR DESCRIPTION
On Ubuntu-18.04 server the kernel module build complains:

    WARNING: modpost: missing MODULE_LICENSE() in motr/extra-libs/src/linux_kernel/galois.o

Solution: add MODULE_LICENSE("LGPL v2.1").